### PR TITLE
Fix Python module being broken

### DIFF
--- a/py/frequenz/api/dispatch/fcr/__init__.py
+++ b/py/frequenz/api/dispatch/fcr/__init__.py
@@ -1,0 +1,3 @@
+# License: MIT
+# Copyright © 2023 Frequenz Energy-as-a-Service GmbH
+"""FCR related dispatch."""

--- a/pytests/test_dispatch.py
+++ b/pytests/test_dispatch.py
@@ -23,3 +23,16 @@ def test_module_import() -> None:
     from frequenz.api.dispatch import dispatch_pb2_grpc
 
     assert dispatch_pb2_grpc is not None
+
+
+def test_fcr_pq_import() -> None:
+    """Test that the FCR prequalification sub module can be imported."""
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.dispatch.fcr import prequalification_pb2
+
+    assert prequalification_pb2 is not None
+
+    # pylint: disable=import-outside-toplevel
+    from frequenz.api.dispatch.fcr import prequalification_pb2_grpc
+
+    assert prequalification_pb2_grpc is not None


### PR DESCRIPTION
It seems like the fcr sub directory was recently added (0.7.0) and that its respective `py` directory structure was not updated respectively. I added an `__init__.py`, and a `py.typed` to it, analogous to its parent directory. That SEEMS to fix the import issue I had on 0.8.1 (simply latest, tried nothing else above 0.6.0). I am not sure though if `py.typed` addition is needed.