### PR TITLE
Improve usability of FcrPrequalificationSettings based on requirements

### DIFF
--- a/proto/frequenz/api/dispatch/fcr/prequalification.proto
+++ b/proto/frequenz/api/dispatch/fcr/prequalification.proto
@@ -27,4 +27,13 @@ message FcrPrequalificationSettings {
 
   // The SoC bound.
   optional SoCBound soc_bound = 3;
+
+  // Whether the initial SoC should be calculated or
+  // simply taken from the SoC bound.
+  //
+  // If true, the initial SoC for the operational phases is calculated
+  // based on the SoC bound and the power limit for the operational phase.
+  //
+  // If false, the initial SoC is set to the lower or upper SoC bound.
+  bool calculate_start_soc = 4;
 }

--- a/proto/frequenz/api/dispatch/fcr/prequalification.proto
+++ b/proto/frequenz/api/dispatch/fcr/prequalification.proto
@@ -10,6 +10,14 @@ syntax = "proto3";
 
 package frequenz.api.dispatch.fcr.prequalification;
 
+message SoCBound {
+  // The upper SoC bound.
+  uint32 upper = 1;
+
+  // The lower SoC bound.
+  uint32 lower = 2;
+}
+
 message FcrPrequalificationSettings {
   // The maximum power to use during the SoC preparation phase.
   optional uint32 power_limit_preparation = 1;
@@ -17,9 +25,6 @@ message FcrPrequalificationSettings {
   // The maximum power to use during the operation phase.
   optional uint32 power_limit_operation = 2;
 
-  // The upper SoC bound.
-  optional uint32 soc_bound_upper = 3;
-
-  // The lower SoC bound.
-  optional uint32 soc_bound_lower = 4;
+  // The SoC bound.
+  optional SoCBound soc_bound = 3;
 }


### PR DESCRIPTION
- Add `precomputed_start_soc` to indicate whether or not start starting SoC for the operational runs should be pre-computed for best use or if it should keep using upper/lower SoC bound.
- refactor SoC bound struct to have either both fully defined or nothing defined at all.