### PR TITLE
Rename fcr_prequal_settings to fcr_prequalification

### DIFF
--- a/proto/frequenz/api/dispatch/dispatch.proto
+++ b/proto/frequenz/api/dispatch/dispatch.proto
@@ -135,7 +135,7 @@ message DispatchFilter {
 
 message DispatchSettings {
   oneof settings {
-    fcr.prequalification.FcrPrequalificationSettings fcr_prequal_settings = 1;
+    fcr.prequalification.FcrPrequalificationSettings fcr_prequalification = 1;
   }
 }
 


### PR DESCRIPTION
Why? Because `prequal` is too cryptic and `_settings` suffix is superfluous.

Closes #13.

Mind, this is not breaking bw-compat on the wire because 1.) i'm the only user of it (still) and 2.) the data member offset remains the same.