### PR TITLE
Add FCR prequalification cancellation event type

### DIFF
--- a/proto/frequenz/api/dispatch/dispatch.proto
+++ b/proto/frequenz/api/dispatch/dispatch.proto
@@ -65,6 +65,10 @@ enum DispatchType {
 
   // FCR prequalification, discharge test
   DISPATCH_TYPE_FCR_PREQUALIFICATION_DISCHARGE = 6;
+
+  // FCR prequalification, cancellation of a charge and discharge test
+  // for a given battery
+  DISPATCH_TYPE_FCR_PREQUALIFICATION_CANCEL = 7;
 }
 
 // Possible dispatch statuses


### PR DESCRIPTION
… to allow cancelling an FCR prequalification for a battery

Closes #12.