### PR TITLE
Remove ability to update existing microgrid ID

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,3 +5,4 @@
 - The `type` field has been removed from update requests, to prevent it from being modified after creation.
 - `DispatchFilter` has been replaced by `DispatchListRequest` as a parameter for `ListDispatches`.
   - The filter has additionally been re-designed, with fields that lack use cases being removed.
+- Removed the ability to update `microgrid_id` on an existing dispatch.

--- a/proto/frequenz/api/dispatch/dispatch.proto
+++ b/proto/frequenz/api/dispatch/dispatch.proto
@@ -177,27 +177,24 @@ message DispatchUpdateRequest {
   // The dispatch identifier
   uint64 id = 1;
 
-  // The microgrid identifier
-  optional uint64 microgrid_id = 2;
-
   // The start time
   // When updating a dispatch, ensure that the starting timestamp is set to
   // the current time or any future time.
   // Timestamps earlier than the current time are not allowed.
-  google.protobuf.Timestamp start_time = 3;
+  google.protobuf.Timestamp start_time = 2;
 
   // The end time
-  google.protobuf.Timestamp end_time = 4;
+  google.protobuf.Timestamp end_time = 3;
 
   // The component selector
-  DispatchComponentSelector selector = 5;
+  DispatchComponentSelector selector = 4;
 
   // The "active" status
-  optional bool is_active = 6;
+  optional bool is_active = 5;
 
   // The "dry run" status
-  optional bool is_dry_run = 7;
+  optional bool is_dry_run = 6;
 
   // The dispatch payload
-  google.protobuf.Struct payload = 8;
+  google.protobuf.Struct payload = 7;
 }


### PR DESCRIPTION
Based on https://github.com/frequenz-floss/frequenz-api-dispatch/pull/28, unblocking when that is merged