### PR TITLE
Add support for mike 2.0.0

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ plugins:
   - literate-nav:
       nav_file: SUMMARY.md
   - mike:
+      alias_type: redirect
       canonical_version: latest
   - mkdocstrings:
       custom_templates: templates


### PR DESCRIPTION
The default setting in this version utilizes symbolic links for aliases, which aren't compatible with GitHub Pages. Therefore, we must specify the use of redirect aliases.

To do this, we set the `alias_type` to redirect within the mike plugin configuration in the `mkdocs.yml` file.