### PR TITLE
Update code and api-common submodule to use v1 paths

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,10 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- Queries that compare against a time interval filter should check for the end time inside the recurrence rule.
+- `end_time` has been renamed `until` and is mutually exclusive with `count`.
+- Update request handlers should check the field mask for which attributes to update.
+- The common api dependency has been udpated so that the `v1` paths for `ComponentCategory` is used.
 
 ## New Features
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,7 @@ plugins:
           import:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
-            - https://frequenz-floss.github.io/frequenz-api-common/v0.3/objects.inv
+            - https://frequenz-floss.github.io/frequenz-api-common/v0.5/objects.inv
             - https://grpc.github.io/grpc/python/objects.inv
             - https://typing-extensions.readthedocs.io/en/stable/objects.inv
   # Note this plugin must be loaded after mkdocstrings to be able to use macros

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -17,7 +17,7 @@ import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-import "frequenz/api/common/components.proto";
+import "frequenz/api/common/v1/microgrid/components/components.proto";
 
 // Service providing operations related to dispatching microgrid components.
 //
@@ -150,7 +150,7 @@ message ComponentSelector {
     ComponentIDs component_ids = 1;
 
     // Component category
-    frequenz.api.common.components.ComponentCategory component_category = 2;
+    frequenz.api.common.v1.microgrid.components.ComponentCategory component_category = 2;
   }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">= 3.11, < 4"
 dependencies = [
   "frequenz-api-common >= 0.5.4, < 0.6",
   "googleapis-common-protos >= 1.56.4, < 2",
-  "grpcio >= 1.51.1, < 2",
+  "grpcio >= 1.54.2, < 2",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Otherwise we can't use other code that uses v1. paths.

~Depends on https://github.com/frequenz-floss/frequenz-api-dispatch/pull/137~