### PR TITLE
Clarify component IDs of different categories are not supported

### DIFF
--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -138,7 +138,11 @@ message TimeIntervalFilter {
 }
 
 // Parameter for controlling which components a dispatch applies to
-// Either a set of component IDs, or all components belonging to a category
+// either a set of component IDs, or all components belonging to a category.
+//
+// When specifying a set of IDs, all IDs should have the same component
+// category, mixing components from different categories in one dispatch
+// message is not supported.
 message ComponentSelector {
   oneof selector {
     // Set of component IDs


### PR DESCRIPTION
Dispatch messages having a selector with a set of IDs should only use components of the same category.