### PR TITLE
Document valid values for `count` and `interval`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ In this release, we have made some changes to the API to improve the user experi
 * Enhanced `payload` documentation.
 * Add YEARLY frequency to the recurrence definition.
 * Add parameters for pagination and sorting.
+* Documentation of valid values for `count` and `interval` fields was added.
 
 ## Bug Fixes
 

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -267,6 +267,7 @@ message RecurrenceRule {
     oneof count_or_until {
       // The number of times this dispatch should recur.
       // If this field is set, the dispatch will recur the given number of times.
+      // Valid values are 1 to 4096.
       uint32 count = 1;
 
       // The end time of this dispatch in UTC.
@@ -283,6 +284,7 @@ message RecurrenceRule {
   // - Every 2 hours:
   //   freq = FREQUENCY_HOURLY
   //   interval = 2
+  // Valid values typically range between 1 and 10_000, depending on the implementation.
   uint32 interval = 2;
 
   // When this dispatch should end.


### PR DESCRIPTION
The values are chosen based on the limits set by the rrule library
used in the service, see:

https://github.com/fmeringdal/rust-rrule?tab=readme-ov-file#limitation-and-limits

`4096` was chosen as it seemed large enough for any sane usecase but not large enough to cause DoS for the service.

refs https://github.com/frequenz-io/frequenz-service-dispatch/issues/122
refs https://github.com/frequenz-io/frequenz-service-dispatch/issues/78
