### PR TITLE
Change description of the EndCriteria.until field.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,7 @@ In this release, we have made some changes to the API to improve the user experi
 * Naming conventions were updated to match API projects.
 * The possibility to update the `dry_run` and `type` fields was removed.
 * The ComponentSelector now can contain multiple component categories.
+* Improve description of the `EndCriteria.until` field.
 
 ## New Features
 

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -416,7 +416,10 @@ message RecurrenceRule {
       uint32 count = 1;
 
       // The end time of this dispatch in UTC.
-      // If this field is set, the dispatch will recur until the given timestamp.
+      // If this field is set, the last recurrence event will start before this
+      // timestamp.
+      // Note that the duration of the event is not considered in this value,
+      // so the dispatch may end after the timestamp.
       google.protobuf.Timestamp until = 2;
     }
   }


### PR DESCRIPTION
To point out that duration doesn't count into that timestamp.