### PR TITLE
Split & Rename the Dispatch object

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,9 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+* `DispatchDetail` is now `Dispatch`
+* `Dispatch` became `DispatchData`
+* Member part of `Dispatch` is now the new message `DispatchMedatata`
 
 ## New Features
 

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -109,7 +109,7 @@ message StreamMicrogridDispatchesResponse {
   }
 
   // Dispatch record returned.
-  DispatchDetail dispatch_detail = 1;
+  Dispatch dispatch = 1;
 
   // Which event this response was triggered by
   Event event = 2;
@@ -119,7 +119,7 @@ message StreamMicrogridDispatchesResponse {
 //
 // Timezone Note: Timestamps are in UTC. It is the responsibility of each microgrid to translate UTC
 // to its local timezone.
-message Dispatch {
+message DispatchData {
   // The dispatch type.
   // Contains user-defined information about what "type" of dispatch this is.
   // Downstream applications that consume the dispatch API are responsible for
@@ -170,24 +170,30 @@ message Dispatch {
 }
 
 // Represents a dispatch, including its metadata
-message DispatchDetail {
+message Dispatch {
+  // Dispatch Metadata (id, create time, etc)
+  DispatchMetadata metadata = 1;
+
+  // The dispatch data
+  DispatchData data = 2;
+}
+
+// Represents the metadata of a dispatch
+message DispatchMetadata {
   // Unique identifier of the microgrid dispatch.
   uint64 dispatch_id = 1;
 
-  // The dispatch data
-  Dispatch dispatch = 2;
-
   // UTC Timestamp when the order was created.
-  google.protobuf.Timestamp create_time = 3;
+  google.protobuf.Timestamp create_time = 2;
 
   // UTC Timestamp of the last update to the order.
-  google.protobuf.Timestamp modification_time = 4;
+  google.protobuf.Timestamp modification_time = 3;
 
   // UTC Timestamp when the dispatch will stop working.
   // Will be calculated internally based on the given: start_time,
   // duration and RecurenceRule
   // None if dispatch duration time is infinite and this value can't be calculated.
-  google.protobuf.Timestamp end_time = 5;
+  google.protobuf.Timestamp end_time = 4;
 }
 
 // Filter parameter for specifying multiple time intervals
@@ -522,7 +528,7 @@ message ListMicrogridDispatchesRequest {
 // A list of dispatches
 message ListMicrogridDispatchesResponse {
   // The dispatches
-  repeated DispatchDetail dispatches = 1;
+  repeated Dispatch dispatches = 1;
 
   // Pagination parameters
   frequenz.api.common.v1.pagination.PaginationParams pagination_params = 4;
@@ -534,13 +540,13 @@ message CreateMicrogridDispatchRequest {
   uint64 microgrid_id = 1;
 
   // Content of the dispatch to be created
-  Dispatch dispatch = 2;
+  DispatchData dispatch_data = 2;
 }
 
 // Response message for creating a new dispatch
 message CreateMicrogridDispatchResponse {
   // The created dispatch
-  DispatchDetail dispatch = 1;
+  Dispatch dispatch = 1;
 }
 
 // Message to update the dispatch with the given ID, with the given attributes
@@ -615,7 +621,7 @@ message UpdateMicrogridDispatchRequest {
 // Response message for updating a dispatch
 message UpdateMicrogridDispatchResponse {
   // The updated dispatch
-  DispatchDetail dispatch = 1;
+  Dispatch dispatch = 1;
 }
 
 // Message to get a single dispatch by its ID
@@ -633,7 +639,7 @@ message GetMicrogridDispatchResponse {
   uint64 microgrid_id = 1;
 
   // The dispatch
-  DispatchDetail dispatch = 2;
+  Dispatch dispatch = 2;
 }
 
 // Message to delete a single dispatch by its ID


### PR DESCRIPTION
* `DispatchDetail` is now `Dispatch`
* `Dispatch` became `DispatchData`
* Member part of `Dispatch` is now the new message `DispatchMedatata`

fixes #193
