### PR TITLE
Prepare release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,6 @@
 # Frequenz Dispatch API Release Notes
 
-## Summary
-
-<!-- Here goes a general summary of what this release is about -->
-
-## Upgrading
-
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
-
 ## New Features
 
-* Added more detailed documentation on how to use pagination.
 * Added `start_immediately` to the create RPC.
 
-## Bug Fixes
-
-<!-- Here goes notable bug fixes that are worth a special mention or explanation -->


### PR DESCRIPTION
The pagination note was from a previous release and should be removed
