### PR TITLE
Add proper permissions to the protolint job in the CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,9 @@ jobs:
   protolint:
     name: Check proto files with protolint
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Fetch sources


### PR DESCRIPTION
Without write permissions on pull requests, the protolint job can't comment on the PRs with the linting results.
