### PR TITLE
Rename Timestamp fields to follow Protobuf guidelines

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,15 @@ This update introduces the possibility to target specific types of batteries, in
 
 * In the `TargetComponents` message, the field `components.component_categories` is now deprecated. See the upgrading section for details.
 
+## Changes
+
+*   Renamed several `google.protobuf.Timestamp` fields in Protobuf messages to align with Google API Design Guide naming conventions (`*_time` suffix):
+    *   `DispatchMetadata.modification_time` is now `update_time`.
+    *   `TimeIntervalFilter.from` is now `from_time`.
+    *   `TimeIntervalFilter.to` is now `to_time`.
+    *   `RecurrenceRule.EndCriteria.until` is now `until_time`.
+    *   **Note:** This is a breaking change for clients using the old field names.
+
 ## Upgrading
 
 * The `TargetComponents` message now accepts an optional `type` too. `.components.component_categories` is now deprecated. Instead `.components.component_categories_types`, a new `CategoryAndType` message that has a required `category` (`ComponentCategory`) and an optional `type` (`oneof BatteryType, EVChargerType, InverterType`) should be used.

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -194,8 +194,8 @@ message DispatchMetadata {
   // UTC Timestamp when the order was created.
   google.protobuf.Timestamp create_time = 2;
 
-  // UTC Timestamp of the last update to the order.
-  google.protobuf.Timestamp modification_time = 3;
+  // UTC time of the last update to the order.
+  google.protobuf.Timestamp update_time = 3;
 
   // UTC Timestamp when the dispatch will stop working.
   // Will be calculated internally based on the given: start_time,
@@ -206,11 +206,11 @@ message DispatchMetadata {
 
 // Filter parameter for specifying multiple time intervals
 message TimeIntervalFilter {
-  // Filter by time >= this UTC timestamp.
-  google.protobuf.Timestamp from = 1;
+  // Filter by time >= this UTC time.
+  google.protobuf.Timestamp from_time = 1;
 
-  // Filter by time <= this UTC timestamp.
-  google.protobuf.Timestamp to = 2;
+  // Filter by time <= this UTC time.
+  google.protobuf.Timestamp to_time = 2;
 }
 
 // Parameters for filtering the dispatch list
@@ -476,7 +476,7 @@ message RecurrenceRule {
       // timestamp.
       // Note that the duration of the event is not considered in this value,
       // so the dispatch may end after the timestamp.
-      google.protobuf.Timestamp until = 2;
+      google.protobuf.Timestamp until_time = 2;
     }
   }
 


### PR DESCRIPTION
- modification_time → update_time
- from → from_time
- to → to_time
- until → until_time

fixes #240