### PR TITLE
dependabot: Group grpc/protobuf updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,10 +36,13 @@ updates:
           - "async-solipsism"
           - "frequenz-api-common"
           - "frequenz-repo-config*"
+          - "grpcio"
+          - "grpcio-tools"
           - "markdown-callouts"
           - "mkdocs-gen-files"
           - "mkdocs-literate-nav"
           - "mkdocstrings*"
+          - "protobuf"
           - "pydoclint"
           - "pytest-asyncio"
       # We group repo-config updates as it uses optional dependencies that are
@@ -51,6 +54,14 @@ updates:
       mkdocstrings:
         patterns:
           - "mkdocstrings*"
+      # We group grpcio and protobuf updates together, as they need special
+      # handling on the pyproject.toml file because of the protobuf/grpcio
+      # build/runtime cross-version guarantees
+      grpc:
+        patterns:
+          - "grpcio"
+          - "grpcio-tools"
+          - "protobuf"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,11 +86,3 @@ updates:
     labels:
       - "part:tooling"
       - "type:tech-debt"
-    groups:
-      compatible:
-        update-types:
-          - "minor"
-          - "patch"
-      artifacts:
-        patterns:
-          - "actions/*-artifact"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,15 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-W=all -Werror -Wdefault::DeprecationWarning -Wdefault::PendingDeprecationWarning -vv"
+addopts = "-vv"
+filterwarnings = [
+  "error",
+  "once::DeprecationWarning",
+  "once::PendingDeprecationWarning",
+  # We use a raw string (single quote) to avoid the need to escape special
+  # chars as this is a regex
+  'ignore:Protobuf gencode version .*exactly one major version older.*:UserWarning',
+]
 testpaths = ["pytests"]
 
 [tool.mypy]


### PR DESCRIPTION
We need to do this because we need to manually update these to ensure the cross-version guarantees between grpcio and protobuf are respected.

Also remove a wrong dependabot group.
