### PR TITLE
Update to common-proto api v0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ requires = [
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#backwards
-  "protobuf == 5.29.5",
-  "grpcio-tools == 1.70.0",
-  "grpcio == 1.70.0",
+  "protobuf == 6.31.1",
+  "grpcio-tools == 1.72.1",
+  "grpcio == 1.72.1",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -43,16 +43,16 @@ classifiers = [
 ]
 requires-python = ">= 3.11, < 4"
 dependencies = [
-  "frequenz-api-common >= 0.5.4, < 0.7",
-  "googleapis-common-protos >= 1.65.0, < 2",
+  "frequenz-api-common >= 0.8.0, < 1.0",
+  "googleapis-common-protos >= 1.70.0, < 2",
   # We can't widen beyond the current value unless we bump the minimum
   # requirements too because of protobuf cross-version runtime guarantees:
   # https://protobuf.dev/support/cross-version-runtime-guarantee/#major
-  "protobuf >= 5.29.3, < 7", # Do not widen beyond 7!
+  "protobuf >= 6.31.1, < 8", # Do not widen beyond 8!
   # We couldn't find any document with a spec about the cross-version runtime
   # guarantee for grpcio, so unless we find one in the future, we'll assume
   # major version jumps are not compatible
-  "grpcio >= 1.70.0, < 2", # Do not widen beyond 2!
+  "grpcio >= 1.72.1, < 2", # Do not widen beyond 2!
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Still keeps the v1 types.

This PR is blocked until the microgrid-client updates to common-api 0.8.0.
We want to ensure that all clients are using the same version of the common-api before merging this PR.
