### PR TITLE
Add id and q filter options

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,8 @@
 
 ## New Features
 
+- In the `DispatchFilter` message, new fields `dispatch_ids`, and `queries` were added to allow filtering dispatches by ID and a free-text search query across the `id` and `type` fields.
+
 <!-- Here goes the main new features and examples or instructions on how to use them -->
 
 ## Bug Fixes

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -301,6 +301,23 @@ message DispatchFilter {
 
   // Optional filter by update time
   frequenz.api.common.v1alpha8.types.Interval update_time_interval = 8;
+
+  // Optional filter by dispatch IDs.
+  // If this field is not set, dispatches with any ID will be included.
+  // Multiple IDs are combined with an OR relationship.
+  repeated uint64 dispatch_ids = 9;
+
+  // Optional free-text search filter.
+  //
+  // This filter is applied to the dispatch `id` and `type` fields.
+  // The `queries` filter combines multiple queries with an OR relationship.
+  //
+  // ID tokens are preceded by a `#` so we can tell if an id is intended or a type.
+  //
+  // - input of [`#4`] will match only the record with id of `4`
+  // - input of [`bar`] will match `bar` and `foobar`
+  // - input of [`#4`, `#24`, `bar`, `foo`] will match ids of `4` and `24` and types `foo` `bar` `foobar` `foolish bartender`
+  repeated string queries = 10;
 }
 
 // Parameter for controlling which components a dispatch applies to


### PR DESCRIPTION
## Pull Request Overview

This PR adds user-friendly filtering options to the dispatch API by introducing two new filter fields: `dispatch_ids` for filtering by specific dispatch IDs and `q` for free-text search across dispatch ID and type fields.

- Added `dispatch_ids` field to enable filtering by specific dispatch IDs with OR logic
- Added `q` field for free-text search with special syntax for ID tokens (using `#` prefix)