### PR TITLE
feat: Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,0 +1,18 @@
+name: Dependabot Auto Manage
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - uses: ad/dependabot-auto-approve@v1
+        with:
+          dependency-type: 'all'
+          auto-merge: 'true'
+          add-label: 'auto-merged'
+          merge-method: 'merge'

--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -10,9 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - uses: ad/dependabot-auto-approve@v1
+      - uses: ad/dependabot-auto-approve@d60f853230db2bb07168b39c180c5dd034b63f28
         with:
           dependency-type: 'all'
           auto-merge: 'true'
           add-label: 'auto-merged'
           merge-method: 'merge'
+          ignore-regex-pr-title: '.*grpc.*,.*protobuf.*'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,8 @@ plugins:
           options:
             paths: ["py"]
             docstring_section_style: spacy
+            docstring_options:
+              warn_missing_types: false
             inherited_members: true
             merge_init_into_class: false
             separate_signature: true

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -12,7 +12,6 @@ syntax = "proto3";
 
 package frequenz.api.dispatch.v1;
 
-import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 80.9.0",
   "setuptools_scm[toml] == 9.2.2",
-  "frequenz-repo-config[api] == 0.13.6",
+  "frequenz-repo-config[api] == 0.14.0",
   # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
@@ -79,7 +79,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.6.23",
   "mkdocstrings[python] == 0.30.1",
   "mkdocstrings-python == 1.18.2",
-  "frequenz-repo-config[api] == 0.13.6",
+  "frequenz-repo-config[api] == 0.14.0",
 ]
 dev-mypy = [
   "mypy == 1.18.2",
@@ -88,7 +88,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-dispatch[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-noxfile = ["nox == 2025.10.16", "frequenz-repo-config[api] == 0.13.6"]
+dev-noxfile = ["nox == 2025.10.16", "frequenz-repo-config[api] == 0.14.0"]
 dev-pylint = [
   "pylint == 4.0.2",
   # For checking the noxfile, docs/ script, and tests
@@ -96,7 +96,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 8.4.2",
-  "frequenz-repo-config[extra-lint-examples] == 0.13.6",
+  "frequenz-repo-config[extra-lint-examples] == 0.14.0",
 ]
 dev = [
   "frequenz-api-dispatch[dev-mkdocs,dev-flake8,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",


### PR DESCRIPTION
This PR adds a GitHub workflow to automatically manage Dependabot pull requests.

This workflow uses the `ad/dependabot-auto-approve@v1` GitHub Action, which may need to be explicitly whitelisted in the organization's settings.