### PR TITLE
Align component target naming with monitoring API

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,12 @@
 
 ## Summary
 
-This is the v1.0.0 release. It is equivalent to v1.0.0-rc3 and introduces a period of API stabilization.
+## What's Changed
+
+* Renamed component target message types and fields for consistency with monitoring API:
+  * `IdSet` → `ElectricalComponentIdSelector`
+  * `CategorySet` → `ElectricalComponentCategorySelectorDeprecated`
+  * `CategoryTypeSet` → `ElectricalComponentCategorySelector`
+  * `CategoryAndType` → `ComponentCategory`
+  * `component_categories` → `component_categories_deprecated` (deprecated field)
+  * `component_categories_types` → `component_categories`

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -388,13 +388,13 @@ message DispatchFilter {
 message TargetComponents {
   // Wrapper for controlling dispatches with a set of component IDs
   // Required as we can't use `repeated` directly in a `oneof`
-  message IdSet {
+  message ElectricalComponentIdSelector {
     // Set of component IDs
     repeated uint64 ids = 1;
   }
 
-  // Deprecated: Use `CategoryTypeSet` instead
-  message CategorySet {
+  // Deprecated: Use `ElectricalComponentCategorySelector` instead
+  message ElectricalComponentCategorySelectorDeprecated {
     option deprecated = true;
     // Set of component categories
     repeated frequenz.api.common.v1alpha8.microgrid.electrical_components
@@ -403,15 +403,15 @@ message TargetComponents {
 
   // Wrapper for controlling dispatches with a set of component categories and optional types
   // Required as we can't use `repeated` directly in a `oneof`
-  message CategoryTypeSet {
+  message ElectricalComponentCategorySelector {
     // Set of component categories
-    repeated CategoryAndType categories = 1;
+    repeated ComponentCategory categories = 1;
   }
 
   // A tuple of a required category and an optional type
   // If a type is specified, it must be a valid type for the given category and
   // only components of that type will be targeted.
-  message CategoryAndType {
+  message ComponentCategory {
     // The category of the target component (required)
     frequenz.api.common.v1alpha8.microgrid.electrical_components
         .ElectricalComponentCategory category = 1;
@@ -437,15 +437,15 @@ message TargetComponents {
 
   oneof components {
     // Set of component IDs
-    IdSet component_ids = 1;
+    ElectricalComponentIdSelector component_ids = 1;
 
     // Deprecated: Component categories
-    // Use `CategoryTypeSet` instead
+    // Use `ElectricalComponentCategorySelector` instead
     // In future versions, this field will be removed.
-    CategorySet component_categories = 2 [deprecated = true];
+    ElectricalComponentCategorySelectorDeprecated component_categories_deprecated = 2 [deprecated = true];
 
     // Component categories with optional types
-    CategoryTypeSet component_categories_types = 3;
+    ElectricalComponentCategorySelector component_categories = 3;
   }
 }
 


### PR DESCRIPTION
## Summary

Synchronize naming conventions for component target selectors with the monitoring API to maintain consistency across Frequenz APIs.

## Changes

- Rename message types to follow `*Selector` suffix pattern
- Add `ElectricalComponent` prefix to selector types for clarity
- Rename `component_categories_types` → `component_categories` (remove redundant `_types` suffix)
- Rename deprecated `component_categories` → `component_categories_deprecated` (add explicit suffix)

This aligns with the naming patterns introduced in frequenz-io/frequenz-api-monitoring-common@e26eeb0.

## Related

- frequenz-io/frequenz-api-monitoring-common#e26eeb0b332d41714aa391897efcd3613aad1b8e