### PR TITLE
build: Bump frequenz-repo-config to 0.14.0

### DIFF
--- a/.github/workflows/auto-dependabot.yaml
+++ b/.github/workflows/auto-dependabot.yaml
@@ -1,19 +1,23 @@
-name: Dependabot Auto Manage
-on: pull_request
+name: Auto-merge Dependabot PR
+
+on:
+  pull_request:
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  dependabot:
-    runs-on: ubuntu-latest
+  auto-merge:
     if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
     steps:
-      - uses: ad/dependabot-auto-approve@d60f853230db2bb07168b39c180c5dd034b63f28
+      - name: Auto-merge Dependabot PR
+        uses: frequenz-floss/dependabot-auto-approve@b93b4ae  # v1.3.2 + ignore-regex-pr-title
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           dependency-type: 'all'
           auto-merge: 'true'
-          add-label: 'auto-merged'
           merge-method: 'merge'
+          add-label: 'tool:auto-merged'
           ignore-regex-pr-title: '.*grpc.*,.*protobuf.*'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,7 @@ plugins:
             show_source: true
             show_symbol_type_toc: true
             signature_crossrefs: true
-          import:
+          inventories:
             # See https://mkdocstrings.github.io/python/usage/#import for details
             - https://docs.python.org/3/objects.inv
             - https://frequenz-floss.github.io/frequenz-api-common/v0.5/objects.inv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 requires = [
   "setuptools == 80.9.0",
   "setuptools_scm[toml] == 9.2.2",
-  "frequenz-repo-config[api] == 0.13.6",
+  "frequenz-repo-config[api] == 0.14.0",
   # We need to pin the protobuf, grpcio and  grpcio-tools dependencies to make
   # sure the code is generated using the minimum supported versions, as older
   # versions can't work with code that was generated with newer versions.
@@ -79,7 +79,7 @@ dev-mkdocs = [
   "mkdocs-material == 9.6.23",
   "mkdocstrings[python] == 0.30.1",
   "mkdocstrings-python == 1.18.2",
-  "frequenz-repo-config[api] == 0.13.6",
+  "frequenz-repo-config[api] == 0.14.0",
 ]
 dev-mypy = [
   "mypy == 1.18.2",
@@ -88,7 +88,7 @@ dev-mypy = [
   # For checking the noxfile, docs/ script, and tests
   "frequenz-api-dispatch[dev-mkdocs,dev-noxfile,dev-pytest]",
 ]
-dev-noxfile = ["nox == 2025.10.16", "frequenz-repo-config[api] == 0.13.6"]
+dev-noxfile = ["nox == 2025.10.16", "frequenz-repo-config[api] == 0.14.0"]
 dev-pylint = [
   "pylint == 4.0.2",
   # For checking the noxfile, docs/ script, and tests
@@ -96,7 +96,7 @@ dev-pylint = [
 ]
 dev-pytest = [
   "pytest == 8.4.2",
-  "frequenz-repo-config[extra-lint-examples] == 0.13.6",
+  "frequenz-repo-config[extra-lint-examples] == 0.14.0",
 ]
 dev = [
   "frequenz-api-dispatch[dev-mkdocs,dev-flake8,dev-formatting,dev-mkdocs,dev-mypy,dev-noxfile,dev-pylint,dev-pytest]",


### PR DESCRIPTION
Updates frequenz-repo-config from 0.13.6 to 0.14.0.

Changes from migration script:
- Updates dependabot workflow to use `frequenz-floss/dependabot-auto-approve`
- Renames `import` to `inventories` in mkdocs.yml for mkdocstrings-python v2 compatibility

Additional:
- Added `ignore-regex-pr-title` for grpc/protobuf PRs that need manual intervention
- Bumped protobuf from 6.31.1 to 6.32.1 (required by mypy-protobuf in repo-config 0.14.0)