### PR TITLE
Deprecate StreamMicrogridDispatches RPC

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,4 +2,18 @@
 
 ## Summary
 
-This is the v1.0.0 release. It is equivalent to v1.0.0-rc3 and introduces a period of API stabilization.
+<!-- Here goes a general summary of what this release is about -->
+
+## Upgrading
+
+- The `StreamMicrogridDispatches` RPC and its request/response messages are now
+  deprecated. They are kept for compatibility, but this controller-facing part
+  of the API will move out as part of a future Dispatch API split.
+
+## New Features
+
+<!-- Here goes the main new features and examples or instructions on how to use them -->
+
+## Bug Fixes
+
+<!-- Here goes notable bug fixes that are worth a special mention or explanation -->

--- a/proto/frequenz/api/dispatch/v1/dispatch.proto
+++ b/proto/frequenz/api/dispatch/v1/dispatch.proto
@@ -69,7 +69,13 @@ service MicrogridDispatchService {
   rpc ListMicrogridDispatches(ListMicrogridDispatchesRequest) returns (ListMicrogridDispatchesResponse);
 
   // Streaming RPC for receiving dispatch updates for a given microgrid
-  rpc StreamMicrogridDispatches(StreamMicrogridDispatchesRequest) returns (stream StreamMicrogridDispatchesResponse);
+  //
+  // Deprecated: This controller-facing operation will be moved out as part of a
+  // future Dispatch API split. It is kept here for now to avoid breaking
+  // existing clients.
+  rpc StreamMicrogridDispatches(StreamMicrogridDispatchesRequest) returns (stream StreamMicrogridDispatchesResponse) {
+    option deprecated = true;
+  }
 
   // Create a new dispatch
   rpc CreateMicrogridDispatch(CreateMicrogridDispatchRequest) returns (CreateMicrogridDispatchResponse);
@@ -87,14 +93,26 @@ service MicrogridDispatchService {
 // Subscribe to a stream of microgrid dispatch requests.
 // This method provides real-time updates on newly or updated dispatch requests for edge-based
 // realtime decision making.
+//
+// Deprecated: This controller-facing message will be moved out as part of a
+// future Dispatch API split. It is kept here for now to avoid breaking existing
+// clients.
 message StreamMicrogridDispatchesRequest {
+  option deprecated = true;
+
   // ID of the microgrid to subscribe to
   uint64 microgrid_id = 1;
 }
 
 // Response to a subscription request for a stream of microgrid dispatches.
 // Real-time information on dispatches affecting a certain microgrid are pushed through this response.
+//
+// Deprecated: This controller-facing message will be moved out as part of a
+// future Dispatch API split. It is kept here for now to avoid breaking existing
+// clients.
 message StreamMicrogridDispatchesResponse {
+  option deprecated = true;
+
   // Dispatch record returned.
   Dispatch dispatch = 1;
 


### PR DESCRIPTION
Deprecate the controller-facing `StreamMicrogridDispatches` RPC and its request/response messages instead of removing them.

This keeps the change non-breaking:

- The RPC, its `StreamMicrogridDispatchesRequest`/`StreamMicrogridDispatchesResponse` messages, and the streaming event import are all retained.
- Deprecation is expressed via `option deprecated = true` plus generic doc notes.
- Existing clients keep working while documenting that this controller-facing part of the API will move out as part of a future Dispatch API split.

No specific target repository or replacement service is named here; the exact split shape is left unspecified for now.